### PR TITLE
버그 및 아이템 관련 수정

### DIFF
--- a/SnakeGame.cpp
+++ b/SnakeGame.cpp
@@ -49,7 +49,7 @@ void SnakeGame::init() {
     init_pair(10, COLOR_RED, COLOR_WHITE);
     
     this->scoreBoard = newwin(12, 20, 5, 72);
-    this->missionBoard = newwin(12, 20, 17, 72);
+    this->missionBoard = newwin(9, 20, 17, 72);
     this->gameBoard = newwin(31, 62, 5, 10);
     this->noticeText = newwin(1, 70, 3, 15);
 }
@@ -94,15 +94,14 @@ void SnakeGame::draw(const string& msg, bool clear) {
         mvwprintw(this->scoreBoard, 1, 7, "Score");
         mvwprintw(this->missionBoard, 1, 7, "Mission");
 
-        mvwprintw(this->scoreBoard, 3, 5, " B : %d / %d", this->snake.get_snake_length(), this->totalCnt.maxSnakeLength);
-        mvwprintw(this->scoreBoard, 5, 5, "GI : %d", this->totalCnt.growthItem);
-        mvwprintw(this->scoreBoard, 7, 5, "PI : %d", this->totalCnt.poisonItem);
+        mvwprintw(this->scoreBoard, 3, 5, "HP : %d", this->mission[this->currStage - 1].poisonItem - totalCnt.poisonItem);
+        mvwprintw(this->scoreBoard, 5, 5, " B : %d / %d", this->snake.get_snake_length(), this->totalCnt.maxSnakeLength);
+        mvwprintw(this->scoreBoard, 7, 5, "GI : %d", this->totalCnt.growthItem);
         mvwprintw(this->scoreBoard, 9, 5, " G : %d", this->totalCnt.gate);
 
         mvwprintw(this->missionBoard, 3, 5, " B : %d / %d", this->snake.get_snake_length(), this->mission[this->currStage - 1].maxSnakeLength);
         mvwprintw(this->missionBoard, 5, 5, "GI : %d / %d", this->currCnt.growthItem, this->mission[this->currStage - 1].growthItem);
-        mvwprintw(this->missionBoard, 7, 5, "PI : %d / %d", this->currCnt.poisonItem, this->mission[this->currStage - 1].poisonItem);
-        mvwprintw(this->missionBoard, 9, 5, " G : %d / %d", this->currCnt.gate, this->mission[this->currStage - 1].gate);
+        mvwprintw(this->missionBoard, 7, 5, " G : %d / %d", this->currCnt.gate, this->mission[this->currStage - 1].gate);
     }
 
     wrefresh(this->scoreBoard);
@@ -122,18 +121,17 @@ void SnakeGame::changePortal() {
 }
 
 void SnakeGame::changeMap(){
-     // 게임 상태 업데이트 작업
-     // 미션 달성 체크 및 스테이지 변경 로직 구현
-     // 스테이지 넘어가는 로직
-     currStage++;
-     SnakeGame::mapUpate(); // 맵 업데이트 호출
-     // 다음 스테이지 초기화 작업 등을 수행
+    // 게임 상태 업데이트 작업
+    // 미션 달성 체크 및 스테이지 변경 로직 구현
+    // 스테이지 넘어가는 로직
+    currStage++;
+    SnakeGame::mapUpate(); // 맵 업데이트 호출
+    // 다음 스테이지 초기화 작업 등을 수행
 }
 
 bool SnakeGame::isMissionClear(){
     bool ret = this->snake.get_snake_length() >= this->mission[this->currStage - 1].maxSnakeLength;
     ret &= this->currCnt.growthItem >= this->mission[this->currStage - 1].growthItem;
-    ret &= this->currCnt.poisonItem >= this->mission[this->currStage - 1].poisonItem;
     ret &= this->currCnt.gate >= this->mission[this->currStage - 1].gate;
     
     return ret;
@@ -325,7 +323,7 @@ void SnakeGame::update(){
         break;
     }
 
-    draw();
+    this->draw();
 }
 
 void SnakeGame::createItems() {

--- a/SnakeGame.cpp
+++ b/SnakeGame.cpp
@@ -94,7 +94,7 @@ void SnakeGame::draw(const string& msg, bool clear) {
         mvwprintw(this->scoreBoard, 1, 7, "Score");
         mvwprintw(this->missionBoard, 1, 7, "Mission");
 
-        mvwprintw(this->scoreBoard, 3, 5, "HP : %d", this->mission[this->currStage - 1].poisonItem - totalCnt.poisonItem);
+        mvwprintw(this->scoreBoard, 3, 5, "HP : %d", this->mission[this->currStage - 1].poisonItem - currCnt.poisonItem);
         mvwprintw(this->scoreBoard, 5, 5, " B : %d / %d", this->snake.get_snake_length(), this->totalCnt.maxSnakeLength);
         mvwprintw(this->scoreBoard, 7, 5, "GI : %d", this->totalCnt.growthItem);
         mvwprintw(this->scoreBoard, 9, 5, " G : %d", this->totalCnt.gate);
@@ -253,7 +253,13 @@ void SnakeGame::update(){
     case ELEMENT_KIND::POISON_ITEM:
         this->changeNoticeMessage("Eat Poison Item..., Snake Length - 1");
         this->totalCnt.poisonItem += 1; 
-        this->currCnt.poisonItem += 1; 
+        this->currCnt.poisonItem += 1;
+
+        if(this->mission[currStage - 1].poisonItem == this->currCnt.poisonItem) {
+            this->setGameStatus(GAME_STATUS::LOSE);
+            return;
+        }
+
         this->setElement(this->snake.head(), ELEMENT_KIND::SNAKE_BODY);
         
         // 현재 꼬리는 ELEMENT_KIND::BOARD로 변경하고, 

--- a/SnakeGame.h
+++ b/SnakeGame.h
@@ -93,11 +93,11 @@ public:
     int currStage;
 
     const MissionCnt mission[5] = {
-        MissionCnt(6, 2, 1, 1),
-        MissionCnt(7, 3, 2, 2),
+        MissionCnt(6, 2, 5, 1),
+        MissionCnt(7, 3, 4, 2),
         MissionCnt(8, 4, 3, 3),
-        MissionCnt(9, 5, 4, 4),
-        MissionCnt(10, 6, 5, 5),
+        MissionCnt(9, 5, 2, 4),
+        MissionCnt(10, 6, 1, 5),
     };
     
     int getGameStatus() { return this->gameStatus; }

--- a/main.cpp
+++ b/main.cpp
@@ -4,7 +4,6 @@
 
 #include "SnakeGame.h"
 
-
 using namespace std;
 using namespace std::chrono;
 
@@ -45,8 +44,10 @@ int main() {
                 flag = true;
                 changeTime = getTime();
                 game->changeNoticeMessage("");
+                game->setDirection(SNAKE_HEAD_DIRECTION::LEFT);
             }
             
+            getch();
             auto calcTime = milliInterval(changeTime);
             if(calcTime < 3000){
                 char msg[50];
@@ -66,26 +67,26 @@ int main() {
             }
 
             continue;
-        }
-
+        } 
+        
         switch (getch()){
-        case 'w':
-            game->setDirection(SNAKE_HEAD_DIRECTION::UP);
-            break;
-        
-        case 'a':
-            game->setDirection(SNAKE_HEAD_DIRECTION::LEFT);
-            break;
-        
-        case 's':
-            game->setDirection(SNAKE_HEAD_DIRECTION::DOWN);
-            break;
-        
-        case 'd':
-            game->setDirection(SNAKE_HEAD_DIRECTION::RIGHT);
-            break;
+            case 'w':
+                game->setDirection(SNAKE_HEAD_DIRECTION::UP);
+                break;
+            
+            case 'a':
+                game->setDirection(SNAKE_HEAD_DIRECTION::LEFT);
+                break;
+            
+            case 's':
+                game->setDirection(SNAKE_HEAD_DIRECTION::DOWN);
+                break;
+            
+            case 'd':
+                game->setDirection(SNAKE_HEAD_DIRECTION::RIGHT);
+                break;
 
-        default: break;
+            default: break;
         }
 
         if(!game->wall.isUsed() && milliInterval(portalTime) >= PORTAL_DURATION){


### PR DESCRIPTION
1.  stage 변경 전 입력이 남아있어 변경 후에 바로 패배 처리되는 오류 수정
2. Poison Item을 HP 감소 아이템으로 변경 / Score Board에 HP 칸 추가, Poison Item 먹을 수록 1칸씩 깎이고, 모두 깎이는 경우 난이도 무관 패배 처리